### PR TITLE
Allow for Symfony console 2 and 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,8 @@
   },
   "require": {
     "php": "~5.5|^7.0",
-    "symfony/console": "^3.0",
-    "symfony/finder": "^3.0"
+    "symfony/console": ">=2.0",
+    "symfony/finder": ">=2.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^4.7"


### PR DESCRIPTION
Sorry I have conflicts here on a old codebase where I cannot install Symfony console due to using Laravel 4.2 which uses 2.

Symfony v2 and v3 seem to work here.
For the lack of use even of Symfony console could event debate on it's requirement just read $argv for directories.
