### PR TITLE
chore: add keyword "static analysis" to prefer install as dev dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,8 @@
   "keywords": [
     "license",
     "code standard",
-    "code style"
+    "code style",
+    "static analysis"
   ],
   "authors": [
     {


### PR DESCRIPTION
https://php.watch/articles/composer-prompt-require-dev-dev-packages